### PR TITLE
Fix Immersive Portals Incompatibility

### DIFF
--- a/src/main/java/com/bawnorton/bettertrims/mixin/EntityMixin.java
+++ b/src/main/java/com/bawnorton/bettertrims/mixin/EntityMixin.java
@@ -74,8 +74,10 @@ public abstract class EntityMixin implements EntityExtender {
         List<ItemStack> equipped = new ArrayList<>();
         for (ItemStack stack : getHandItems()) equipped.add(stack);
         equipped.removeIf(stack -> stack.getItem() instanceof ArmorItem);
-        for (ItemStack stack : getArmorItems()) equipped.add(stack);
-        equipped.removeIf(ItemStack::isEmpty);
+        if(getArmorItems()!=null) {
+            for (ItemStack stack : getArmorItems()) equipped.add(stack);
+            equipped.removeIf(ItemStack::isEmpty);
+        }
         return equipped;
     }
 


### PR DESCRIPTION
Noticed while setting up a modpack the game crashed while generating an immersive portal
```
java.lang.NullPointerException: Cannot invoke "java.lang.Iterable.iterator()" because the return value of "net.minecraft.class_1297.method_5661()" is null
	at net.minecraft.class_1297.betterTrims$getTrimmables(class_1297.java:3875) ~[client-intermediary.jar:?]
	at net.minecraft.class_1297.modifyReturnValue$zze000$bettertrims$checkIfNetheriteTrimmed(class_1297.java:3852) ~[client-intermediary.jar:?]
```
I tested in isolation, with just the 2 mods and the issue persisted, so I decided to attempt a fix.

Based on the crash report, this crash is because immersive portal entities return null to getArmorItems(), which makes sense as it would make no sense if they could wear armor. (Not that that is necessarily the best practice, should probably just be returning an empty list instead) However, this mod immediately tries to use it in a for loop without checking, causing a crash even with just the two mods. This change just implements a check.

After making this change and recompiling on my computer, the crash went away and compatibility was restored.