### PR TITLE
Fix newer versions of MixinSquared breaking older versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -165,7 +165,7 @@ if(loader.isFabric) {
         }
 
         include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.4.1")!!)!!)
-        runtimeOnly("com.bawnorton.mixinsquared:mixinsquared-fabric:0.2.0")
+        runtimeOnly("com.github.bawnorton:mixinsquared-fabric:0.2.0")
 
         if (mcVersion.lessThan("1.21")) {
             modRuntimeOnly("maven.modrinth:allthetrims:${property("allthetrims")}")


### PR DESCRIPTION
MixinSquared migrated from jitpack to my own maven when 0.2.0-beta.5 released, I did not know that this would break compatibility with older versions of MixinSquared as the maven group changed from `com.github.bawnorton` to `com.bawnorton` causing mod loaders to think they were different mods. This PR reverts that change to allow for compatibility with older versions of MixinSquared. I aplogize for the inconvenience, I was not aware of the implications of this change.